### PR TITLE
Remove vantaa references

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Currently, there's no user interface for creating youth clubs. You can insert th
 
 ## Testing SMS functionality
 
-To test SMS functionality locally, rename `.env.template` file to `.env` in */backend* and update the Telia username/password/user fields with right values *(check in Microsoft Teams - Vantaan Kaupunki Wiki page to see whom to contact to get the values)*
+To test SMS functionality locally, rename `.env.template` file to `.env` in */backend* and update the Telia username/password/user fields with right values
 
 ## Creating test data
 
@@ -137,50 +137,3 @@ There's a lot of files under node_modules and they are all being watched, reachi
     echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
 Increasing memory limits for Docker might also help if for example you are using the Docker Desktop app to constrain them in the first place.
-
-## Environments, AWS and CI
-
-### CI
-
-GitHub uses github-actions to push master branch to test-environment, when push or merge occurs to the master branch. For more information, see the "Actions" tab in GitHub.
-
-### Test environment
-
-Application runs in Elastic Container Service (eu-west-1), with 3 different services:
-
-* [youth-club-server-service](https://api.mobiilinuta-admin-test.com/api)
-* [youth-club-mobile-front](http://youth-club-mobile-lb-74625212.eu-west-1.elb.amazonaws.com)
-* [youth-club-admin-front-2](https://mobiilinuta-admin-test.com)
-
-Application images are stored in Elastic Container Registry.
-You shouldn't need to update images or services manually, since Github does that for you.
-
-### Production environment
-
-Application runs in Elastic Beanstalk in a single container (using Dockerfile) and is deployed via command-line manually. The name is **nutakortti-vantaa-prod**. See next section for updating the production environment using EB CLI tools.
-
-* [Junior-app](https://nutakortti.vantaa.fi)
-* [Admin-app](https://nutakortti.vantaa.fi/nuorisotyontekijat)
-* [Api](https://nutakortti.vantaa.fi/api)
-
-Production logs are found in AWS CloudWatch under `/aws/elasticbeanstalk/nutakortti-vantaa-prod/var/log/` (just go to CloudWatch and select Log groups from the left panel). The current app log and nginx access/error logs are of most interest.
-
-### Updating the production environment using EB CLI tools
-
-Install the tools (for quick setup, follow the README in GitHub):
-* [AWS docs](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3-install.html)
-* [GitHub](https://github.com/aws/aws-elastic-beanstalk-cli-setup)
-* Remember to add EB CLI to PATH (e.g. `export PATH="/home/username/.ebcli-virtual-env/executables:$PATH"`).
-
-Configure the EB CLI:
-* [AWS docs](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3-configuration.html)
-* Note: this process only initializes the current directory/repository on your computer. The relevant files have been added to gitignore.
-1. Go to project directory root (where this file is). Type: `eb init`.
-2. Select `eu-central-1` as the location (unless something's been changed).
-3. If you haven't set up your AWS credentials yet, provide your personal Access key ID and Secret access key. You got them when receiving the AWS credentials (you should have got the following: **User name,Password,Access key ID,Secret access key,Console login link**). On Linux/OS X, the credentials will be stored in `~/.aws/config`.
-4. Select the `Nutakortti` as application. Don't continue with CodeCommit (defaults to N).
-5. Ensure the environment is set up by typing `eb list`. You should see **nutakortti-vantaa-prod**.
-
-**Deploy a new version to production:**
-* While in the project root directory, type: `eb deploy nutakortti-vantaa-prod`
-* To see how things are progressing, type: `eb events -f`

--- a/admin-frontend/README.md
+++ b/admin-frontend/README.md
@@ -19,9 +19,3 @@ Admin-frontend is build using `react-admin` (running on port 3002).
 ## Creating an admin user
 
 The application needs at least one admin user to work properly. See the generic README.md at the root of the repository *(../README.md)* on instructions how to create one.
-
-## Task definition / environment variables / secrets
-
-There are two environment variables:
-* `REACT_APP_ENDPOINT`: the base API URL, e.g. "https://api.mobiilinuta-admin-test.com/api"
-* `REACT_APP_ADMIN_FRONTEND_URL`: URL where to go when an admin logouts, e.g. "https://nutakortti.vantaa.fi/nuorisotyontekijat/"

--- a/admin-frontend/package.json
+++ b/admin-frontend/package.json
@@ -22,7 +22,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject",
+    "eject": "react-scripts eject"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/admin-frontend/package.json
+++ b/admin-frontend/package.json
@@ -23,7 +23,6 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "deploy": "aws s3 sync build/ s3://vantaa-youth-pwa-admin-dev"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/admin-frontend/public/index.html
+++ b/admin-frontend/public/index.html
@@ -6,7 +6,7 @@
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
-  <meta name="description" content="Kirjaudu Vantaan nuorisotilaan mobiilipalvelun avulla." />
+  <meta name="description" content="Kirjaudu Espoon nuorisotilaan mobiilipalvelun avulla." />
   <link rel="apple-touch-icon" href="logo192.png" />
   <!--
                       manifest.json provides metadata used when your web app is installed on a
@@ -22,7 +22,7 @@
                       work correctly both with client-side routing and a non-root public URL.
                       Learn how to configure a non-root public URL by running `npm run build`.
                     -->
-  <title>Nutakortti - Nuorisotyöntekijä</title>
+  <title>Nuori Espoo jäsenkortti</title>
 </head>
 
 <body>

--- a/backend/README.md
+++ b/backend/README.md
@@ -79,7 +79,7 @@ The application needs at least one admin user to work properly. See the generic 
 
 ## Testing SMS functionality
 
-To test SMS functionality locally, rename `.env.template` file to `.env` and update the Telia username/password/user fields with right values _(check in Microsoft Teams - Vantaan Kaupunki Wiki page to see whom to contact to get the values)_
+To test SMS functionality locally, rename `.env.template` file to `.env` and update the Telia username/password/user fields with right values
 
 ## Task definition / environment variables / secrets
 
@@ -112,8 +112,8 @@ The environment variables are:
 
 Additionally, the frontend apps require these environment variables:
 
-- `REACT_APP_ENDPOINT`: the base API URL, e.g. "https://api.mobiilinuta-admin-test.com/api"
-- `REACT_APP_ADMIN_FRONTEND_URL`: (only for admin-frontend) URL where to go when an admin logouts, e.g. "https://nutakortti.vantaa.fi/nuorisotyontekijat/"
+- `REACT_APP_ENDPOINT`: the base API URL
+- `REACT_APP_ADMIN_FRONTEND_URL`: (only for admin-frontend) URL where to go when an admin logouts
 
 New env variables added for ad integration
 

--- a/backend/certs/README.md
+++ b/backend/certs/README.md
@@ -3,7 +3,7 @@
 ## Terminology
 
 * IdP: Identity provider, in this case the Suomi.fi Tunnistus service.
-* SP: Service provider, or Vantaan Mobiilinutakortti (i.e. this application).
+* SP: Service provider
 * SAML2: SAML 2.0, an XML-based protocol which is in this case used to pass information about the end user between the IdP and SP.
 * X.509: a standard defining the format of public key certificates.
 * CA: Certificate Authority, an entity that issues digital certificates.
@@ -18,9 +18,11 @@ The certificate used in SAML2 communication is different to the TLS certificate 
 
 ## Production environment
 
-For production environment, a certificate issued by a CA is needed. This is handled via the city of Vantaa and their agreements with a CA.
+For production environment, a certificate issued by a CA is needed. This is handled via the city of Espoo and their agreements with a CA.
 
 ## Test environment
+
+** This contains legacy example values from the vantaa repository that this repository was originally forked from **
 
 For the test environment, a self-signed certificate is used. The procedure for creating the certificate using OpenSSL is as follows:
 

--- a/backend/src/sso/samlhelper.ts
+++ b/backend/src/sso/samlhelper.ts
@@ -19,7 +19,7 @@ export class SAMLHelper {
 
     Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" (a constant)
     NameQualifier="https://testi.apro.tunnistus.fi/idp1" (the IdP)
-    SPNameQualifier="https://nutakortti-test.vantaa.fi" (the EntityID)
+    SPNameQualifier=(Espoo EntityID)
 
   If these attributes are not provided, the StatusCode in the Response SAML will be erroneous.
   Saml2-js builds the XML using xmlbuilder but does not provide a way at the moment for giving extra attributes.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject",
+    "eject": "react-scripts eject"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,6 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "deploy": "aws s3 sync build/ s3://vantaa-youth-pwa-frontend-dev"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,7 +9,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="white">
   <meta name="apple-mobile-web-app-title" content="Nutakortti">
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
-  <meta name="description" content="Kirjaudu Vantaan nuorisotilaan mobiilipalvelun avulla." />
+  <meta name="description" content="Kirjaudu Espoon nuorisotilaan mobiilipalvelun avulla." />
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/apple-touch-icon.png">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <!--

--- a/frontend/src/customizations/index.tsx
+++ b/frontend/src/customizations/index.tsx
@@ -6,7 +6,7 @@ export const languages: Language[] = ['fi', 'sv', 'en']
 export const hiddenFormFields: CustomizableFormField[] = []
 
 const TopLogo = styled(function TopLogo({ className }: { className?: string }) {
-  return <h2 className={className}>Vantaa</h2>
+  return <h2 className={className}>Espoo</h2>
 })`
   max-width: 800px;
   margin: 0 auto;


### PR DESCRIPTION
Remove the most obvious vantaa references mostly from documentation and comments.

The remaining references are in most in the configuration files which are overridden with out own customizations.
These can be replaced the the override values once we fix the repository structure so that this repository contains the CI actions.