### PR TITLE
feat: load SFI IDP certs from SSM env vars instead of bundled files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository structure
+
+Monorepo with three separately-built apps bundled into one Docker image:
+- `backend/` — NestJS API server (port 3000), also statically serves the two frontends
+- `frontend/` — React + Redux-Saga app for youth users (port 3001 in dev)
+- `admin-frontend/` — React Admin + Vite app for youth workers (port 3002 in dev)
+
+## Commands
+
+### Local development
+
+Start infrastructure, then each app in its own terminal:
+
+```bash
+docker-compose up -d db redis                              # PostgreSQL + Redis
+
+cd backend && npm install && ./run-dev.sh                  # API on :3000 (sets AD_MOCK=true etc.)
+cd frontend && npm install && PORT=3001 npm start          # Youth app on :3001
+cd admin-frontend && npm install && PORT=3002 npm run dev  # Worker app on :3002
+```
+
+### Backend
+
+```bash
+cd backend
+npm run start:dev    # Watch mode
+npm run build        # Compile TypeScript → dist/
+npm run test         # Jest unit tests
+npm run test:watch   # Jest watch
+npm run test:e2e     # E2E tests
+npm run lint         # TSLint
+npm run lint:fix
+npm run format       # Prettier
+```
+
+Run a single test file:
+```bash
+cd backend && npx jest path/to/file.spec.ts
+```
+
+### Frontend / Admin-frontend
+
+```bash
+npm run lint         # frontend: TSLint  |  admin-frontend: ESLint --max-warnings 0
+npm run lint:fix     # admin-frontend only
+npm run build        # production bundle
+```
+
+## Architecture
+
+### Single-container deployment
+
+The Dockerfile builds both React apps first (frontend → `backend/public/`, admin-frontend → `backend/public/nuorisotyontekijat/`), then builds the NestJS backend. At runtime a single Node process serves the API and both frontends. The docker-compose `app` service represents the whole stack.
+
+### Dual authentication model
+
+Two completely separate SSO flows coexist:
+
+**Suomi.fi SAML** (`backend/src/sso/`) — for youth end-users
+- Uses `saml2-js`; IDP certificates loaded from files in `backend/certs/` at startup (`tunnistus-{test|prod}-1.cer` and `-2.cer`)
+- `CERT_SELECTION` env var (`test` / `prod`) selects which cert set is loaded
+- After ACS callback, a `securityContext` JWT is base64-encoded into a redirect query param; the frontend stores it client-side
+
+**Azure AD SAML** (`backend/src/ad-sso/`) — for youth workers (admins)
+- Uses `@node-saml/node-saml`; IDP cert and SP private key come from env vars (`AD_SAML_*`)
+- Session data (nameId, sessionIndex) encrypted with AES-256-CBC (`CRYPTO_SECRET_KEY`) and stored in a signed httpOnly cookie (`COOKIE_SECRET`)
+- `AD_MOCK=true` enables a fake-login endpoint for local development
+- On successful callback, backend upserts the admin record, then issues a JWT
+
+### JWT usage differs by user type
+
+- **Youth workers (admins):** JWT issued into an httpOnly cookie; refresh via `GET /api/admin/refresh`
+- **Youth users (juniors):** JWT sent as Bearer token in Authorization header
+
+Guards: `JwtAuthGuard` validates the token; `RolesGuard` checks the role (JUNIOR / ADMIN / SUPERUSER) against the endpoint's `@AllowedRoles()` decorator.
+
+### QR check-in flow
+
+`POST /api/club/check-in` has **no authentication guard by design** — it must be callable by the admin-frontend camera scanner without a pre-authenticated context. The QR code payload contains the junior's identity.
+
+### Database
+
+TypeORM with `synchronize: true` — schema is auto-updated from entity classes on every startup. No migration files. Core entities: `Admin`, `Junior`, `Club`, `CheckIn`, `Lockout`. A nightly cron job (`@Cron`) deletes `CheckIn` rows older than 14 days.
+
+### State management (frontend only)
+
+The `frontend/` uses Redux + Redux-Saga for all async API calls. The `admin-frontend/` relies on React Admin's built-in data provider pattern instead.

--- a/backend/src/sso/sso.service.ts
+++ b/backend/src/sso/sso.service.ts
@@ -9,6 +9,20 @@ import { SAMLHelper } from './samlhelper';
 import { AcsDto, SecurityContextDto } from '../authentication/dto';
 import { AuthenticationService } from '../authentication/authentication.service';
 
+// Read SFI IDP certs from SUOMIFI_IDP_CERT_<year> env vars (injected from SSM).
+// saml2-js expects raw base64 — strip PEM headers if present.
+// Falls back to bundled cert files for local development when no env vars are set.
+function sfiIdpCerts(certSelection: string): string[] {
+  const fromEnv = Object.entries(process.env)
+    .filter(([k]) => k.startsWith('SUOMIFI_IDP_CERT_'))
+    .map(([, v]) => (v ?? '').replace(/-----[^\n]+-----/g, '').replace(/\s+/g, ''))
+    .filter(Boolean);
+  if (fromEnv.length > 0) return fromEnv;
+  return [1, 2].map((n) =>
+    fs.readFileSync(`certs/tunnistus-${certSelection}-${n}.cer`).toString().trim(),
+  );
+}
+
 @Injectable()
 export class SsoService {
   private readonly entity_id: string;
@@ -57,14 +71,7 @@ export class SsoService {
       sso_logout_url:
         process.env.SSO_LOGOUT_URL ||
         'https://testi.apro.tunnistus.fi/idp/profile/SAML2/Redirect/SLO',
-      certificates: [
-        fs
-          .readFileSync('certs/tunnistus-' + cert_selection + '-1.cer')
-          .toString(),
-        fs
-          .readFileSync('certs/tunnistus-' + cert_selection + '-2.cer')
-          .toString(),
-      ],
+      certificates: sfiIdpCerts(cert_selection),
     };
     this.idp = new saml2.IdentityProvider(idp_options);
 


### PR DESCRIPTION
Replace fs.readFileSync of tunnistus-{sel}-{1,2}.cer with runtime reading
of SUOMIFI_IDP_CERT_<year> env vars (injected from SSM by ECS). Falls back
to bundled cert files for local development when no env vars are set.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
